### PR TITLE
Explicitly import librosa.display

### DIFF
--- a/basic_feature_extraction.ipynb
+++ b/basic_feature_extraction.ipynb
@@ -10,7 +10,7 @@
    "source": [
     "%matplotlib inline\n",
     "import seaborn # import before other plotting libraries\n",
-    "import numpy, scipy, matplotlib.pyplot as plt, librosa, sklearn, urllib, IPython.display, stanford_mir\n",
+    "import numpy, scipy, matplotlib.pyplot as plt, librosa, librosa.display, sklearn, urllib, IPython.display, stanford_mir\n",
     "plt.rcParams['figure.figsize'] = (14,5)"
    ]
   },


### PR DESCRIPTION
librosa.display must be imported explicitly now. See this https://github.com/librosa/librosa/issues/441